### PR TITLE
Pass through ssl options & allow customizing the apache config filename

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -9,6 +9,6 @@ collections:
   - 'community.crypto'
 
 roles:
-  - src: 'ansibleguy.infra_apache'
+  - src: 'anon8675309.infra_apache'
   - src: 'ansibleguy.infra_certs'
   - src: 'ansibleguy.infra_mariadb'

--- a/tasks/debian/web.yml
+++ b/tasks/debian/web.yml
@@ -20,7 +20,7 @@
 - name: ZoneMinder | Debian | Webserver | Adding apache app-config
   ansible.builtin.template:
     src: 'templates/etc/apache2/sites-available/zoneminder.conf.j2'
-    dest: '/etc/apache2/sites-available/site_zoneminder_app.conf'
+    dest: "/etc/apache2/sites-available/site_{{ZM_CONFIG.apache.name | default('zoneminder')}}_app.conf"
     owner: 'root'
     group: 'root'
     mode: 0644

--- a/tasks/debian/web.yml
+++ b/tasks/debian/web.yml
@@ -2,7 +2,7 @@
 
 - name: ZoneMinder | Debian | Webserver | Managing Apache2
   ansible.builtin.include_role:
-    name: ansibleguy.infra_apache
+    name: anon8675309.infra_apache
   vars:
     apache:
       security: "{{ ZM_CONFIG.apache.security }}"

--- a/tasks/debian/web.yml
+++ b/tasks/debian/web.yml
@@ -8,6 +8,7 @@
       security: "{{ ZM_CONFIG.apache.security }}"
       modules:
         present: "{{ ZM_HC.apache.modules }}"
+      ssl: "{{ ZM_CONFIG.apache.ssl }}"
       sites:
         zoneminder: "{{ zm_apache_path | combine(ZM_CONFIG.apache, recursive=true) }}"
   no_log: true


### PR DESCRIPTION
This change allows passing the ssl options through to the apache configuration, which was necessary because I use a different path for my x.509 certs, which already exist on the target machine, and I don't have a separate chainfile (I amm not renewing them using letsencrypt, but I am using the ACME protocol).

The other change was to allow putting the FQDN into the apache configuration filename.  Instead of the zm_site_name being hardcoded to "zoneminder" now it can be set by the user.  If not explicitly set, it falls back to "zoneminder".

Note: I had to change the requirements to point to my repo for my own deployment & testing.  Please edit this MR to not include those changes. If I remove these change in my repo before everything is merged into your repos, it will break my deployment scripts.

All changes are backward compatible.